### PR TITLE
Update copyright year to use dynamic current year

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -167,7 +167,7 @@ export default function Home() {
             color: '#9ca3af'
           }}>
             <p style={{ margin: 0 }}>
-              © 2024 Simple Invoice Generator. Made for small businesses everywhere.
+              © {new Date().getFullYear()} Simple Invoice Generator. Made for small businesses everywhere.
             </p>
           </div>
         </div>


### PR DESCRIPTION
- Replace hardcoded 2024 with new Date().getFullYear()
- Ensures copyright year is always current without manual updates